### PR TITLE
Updated index to print the inner method for Karma

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Run Mocha",
+            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+            "args": [
+                "test.js",
+                "--opts",
+                "mocha.opts",
+            ],
+            "cwd": "${workspaceRoot}",
+            "outFiles": []
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,14 @@
         "**/.DS_Store": true,
         "**/*.js": true,
         "**/*.js.map": true
-    }
+    },
+    "javascript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+    "javascript.format.insertSpaceBeforeFunctionParenthesis": false,
+    "typescript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+    "typescript.format.insertSpaceBeforeFunctionParenthesis": false,
+    "editor.tabSize": 4,
+    // Insert spaces when pressing Tab. This setting is overriden
+    // based on the file contents when `editor.detectIndentation` is true.
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": true
 }

--- a/bin/watch.ts
+++ b/bin/watch.ts
@@ -122,7 +122,7 @@ function compilationComplete() {
 const tscp = spawn(argv.tsc, ["-p", argv.project, "-w"]);
 const tscl = readline.createInterface({ input: tscp.stdout });
 tscl.on("line", (line) => {
-    if (line.indexOf("Compilation complete.") >= 0) {
+    if (line.indexOf("Compilation complete.") >= 0 || line.indexOf("Found ") >= 0) {
         console.log(line);
         compilationComplete();
     } else if (line.indexOf("File change detected.") >= 0) {

--- a/bin/watch.ts
+++ b/bin/watch.ts
@@ -2,9 +2,9 @@
 
 // Run "tsc" with watch, upon successful compilation run mocha tests.
 
-import * as chalk from "chalk";
+import chalk from "chalk";
 import * as child_process from "child_process";
-import { spawn } from "cross-spawn";
+import * as spawn from "cross-spawn";
 import * as readline from "readline";
 import * as yargs from "yargs";
 

--- a/index.ts
+++ b/index.ts
@@ -63,10 +63,10 @@ interface SuiteProto {
 export type SuiteTrait = (this: Mocha.ISuiteCallbackContext, ctx: Mocha.ISuiteCallbackContext, ctor: SuiteCtor) => void;
 export type TestTrait = (this: Mocha.ITestCallbackContext, ctx: Mocha.ITestCallbackContext, instance: SuiteProto, method: Function) => void;
 
-const noname = (cb: ((context, done?) => any), innerFunction?: Function): () => any => {
+const noname = (cb: ((done?: Function) => any), innerFunction?: Function): () => any => {
     if (innerFunction && cb) {
         let wrapperResult: any = function() {
-            cb.apply(this, arguments);
+            return cb.apply(this, arguments);
         };
         if (cb.length === 1) {
             // we need to handle the done callback explicitly in the definition for mocha to respect it correctly
@@ -249,8 +249,8 @@ function suiteClassCallback(target: SuiteCtor, context: TestFunctions) {
         }
 
         function applyTestFunc(testFunc: Function, testName: string,
-            method: Function, callArgs: any[],
-            sync: boolean = true) {
+                               method: Function, callArgs: any[],
+                               sync: boolean = true) {
             if (sync) {
                 testFunc(testName, noname(function(this: Mocha.ITestCallbackContext) {
                     applyDecorators(this, prototype, method, instance);

--- a/index.ts
+++ b/index.ts
@@ -65,12 +65,12 @@ export type TestTrait = (this: Mocha.ITestCallbackContext, ctx: Mocha.ITestCallb
 
 const noname = (cb: ((context, done?) => any), innerFunction?: Function): () => any => {
     if (innerFunction && cb) {
-        let wrapperResult: any = function(context) {
+        let wrapperResult: any = function() {
             cb.apply(this, arguments);
         };
-        if (cb.length === 2) {
+        if (cb.length === 1) {
             // we need to handle the done callback explicitly in the definition for mocha to respect it correctly
-            wrapperResult = function(context, done) {
+            wrapperResult = function(done) {
                 return cb.apply(this, arguments);
             };
         }

--- a/index.ts
+++ b/index.ts
@@ -64,7 +64,7 @@ export type SuiteTrait = (this: Mocha.ISuiteCallbackContext, ctx: Mocha.ISuiteCa
 export type TestTrait = (this: Mocha.ITestCallbackContext, ctx: Mocha.ITestCallbackContext, instance: SuiteProto, method: Function) => void;
 
 const noname = (cb: Function, innerFunction?: Function) => {
-    const wrapperResult = function (...args: any[]) {
+    const wrapperResult = function(...args: any[]) {
         return cb.apply(this, args);
     };
     //wrap the toString method 
@@ -109,18 +109,18 @@ function applySuiteTraits(context: Mocha.ISuiteCallbackContext, target: SuiteCto
 }
 
 function suiteClassCallback(target: SuiteCtor, context: TestFunctions) {
-    return function () {
+    return function() {
         applySuiteTraits(this, target);
         applyDecorators(this, target, target, target);
         let instance;
         if (target.before) {
             if (target.before.length > 0) {
-                context.before(function (done) {
+                context.before(function(done) {
                     applyDecorators(this, target, target.before, target);
                     return target.before(done);
                 });
             } else {
-                context.before(function () {
+                context.before(function() {
                     applyDecorators(this, target, target.before, target);
                     return target.before();
                 });
@@ -128,12 +128,12 @@ function suiteClassCallback(target: SuiteCtor, context: TestFunctions) {
         }
         if (target.after) {
             if (target.after.length > 0) {
-                context.after(function (done) {
+                context.after(function(done) {
                     applyDecorators(this, target, target.after, target);
                     return target.after(done);
                 });
             } else {
-                context.after(function () {
+                context.after(function() {
                     applyDecorators(this, target, target.after, target);
                     return target.after();
                 });
@@ -143,20 +143,20 @@ function suiteClassCallback(target: SuiteCtor, context: TestFunctions) {
         let beforeEachFunction: (() => any) | ((done: Function) => any);
         if (prototype.before) {
             if (prototype.before.length > 0) {
-                beforeEachFunction = noname(function (this: Mocha.IHookCallbackContext, done: Function) {
+                beforeEachFunction = noname(function(this: Mocha.IHookCallbackContext, done: Function) {
                     instance = new target();
                     applyDecorators(this, prototype, prototype.before, instance);
                     return prototype.before.call(instance, done);
                 });
             } else {
-                beforeEachFunction = noname(function (this: Mocha.IHookCallbackContext) {
+                beforeEachFunction = noname(function(this: Mocha.IHookCallbackContext) {
                     instance = new target();
                     applyDecorators(this, prototype, prototype.before, instance);
                     return prototype.before.call(instance);
                 });
             }
         } else {
-            beforeEachFunction = noname(function (this: Mocha.IHookCallbackContext) {
+            beforeEachFunction = noname(function(this: Mocha.IHookCallbackContext) {
                 instance = new target();
             });
         }
@@ -165,7 +165,7 @@ function suiteClassCallback(target: SuiteCtor, context: TestFunctions) {
         let afterEachFunction: (() => any) | ((done: Function) => any);
         if (prototype.after) {
             if (prototype.after.length > 0) {
-                afterEachFunction = noname(function (this: Mocha.IHookCallbackContext, done) {
+                afterEachFunction = noname(function(this: Mocha.IHookCallbackContext, done) {
                     try {
                         applyDecorators(this, prototype, prototype.after, instance);
                         return prototype.after.call(instance, done);
@@ -174,7 +174,7 @@ function suiteClassCallback(target: SuiteCtor, context: TestFunctions) {
                     }
                 });
             } else {
-                afterEachFunction = noname(function (this: Mocha.IHookCallbackContext) {
+                afterEachFunction = noname(function(this: Mocha.IHookCallbackContext) {
                     try {
                         applyDecorators(this, prototype, prototype.after, instance);
                         return prototype.after.call(instance);
@@ -184,7 +184,7 @@ function suiteClassCallback(target: SuiteCtor, context: TestFunctions) {
                 });
             }
         } else {
-            afterEachFunction = noname(function (this: Mocha.IHookCallbackContext) {
+            afterEachFunction = noname(function(this: Mocha.IHookCallbackContext) {
                 instance = undefined;
             });
         }
@@ -240,13 +240,13 @@ function suiteClassCallback(target: SuiteCtor, context: TestFunctions) {
             method: Function, callArgs: any[],
             sync: boolean = true) {
             if (sync) {
-                testFunc(testName, noname(function (this: Mocha.ITestCallbackContext) {
+                testFunc(testName, noname(function(this: Mocha.ITestCallbackContext) {
                     applyDecorators(this, prototype, method, instance);
                     applyTestTraits(this, instance, method);
                     return method.call(instance, ...callArgs);
                 }, method));
             } else {
-                testFunc(testName, noname(function (this: Mocha.ITestCallbackContext, done) {
+                testFunc(testName, noname(function(this: Mocha.ITestCallbackContext, done) {
                     applyDecorators(this, prototype, method, instance);
                     applyTestTraits(this, instance, method);
                     return method.call(instance, ...callArgs, done);
@@ -288,7 +288,7 @@ function suiteOverload(overloads: {
     suiteDecorator(...traits: SuiteTrait[]): ClassDecorator;
     suiteDecoratorNamed(name: string, ...traits: SuiteTrait[]): ClassDecorator;
 }) {
-    return function () {
+    return function() {
         if (arguments.length === 2 && typeof arguments[0] === "string" && typeof arguments[1] === "function" && !arguments[1][isTraitSymbol]) {
             return overloads.suite.apply(this, arguments);
         } else if (arguments.length === 1 && typeof arguments[0] === "function" && !arguments[0][isTraitSymbol]) {
@@ -325,7 +325,7 @@ function makeSuiteFunction(suiteFunc: (ctor?: SuiteCtor) => Function, context: T
 }
 
 function suiteFuncCheckingDecorators(context: TestFunctions) {
-    return function (ctor?: SuiteCtor) {
+    return function(ctor?: SuiteCtor) {
         if (ctor) {
             const shouldSkip = ctor[skipSymbol];
             const shouldOnly = ctor[onlySymbol];
@@ -391,7 +391,7 @@ function testOverload(overloads: {
     testDecorator(...traits: TestTrait[]): PropertyDecorator & MethodDecorator;
     testDecoratorNamed(name: string, ...traits: TestTrait[]): PropertyDecorator & MethodDecorator;
 }) {
-    return function () {
+    return function() {
         if (arguments.length === 2 && typeof arguments[0] === "string" && typeof arguments[1] === "function" && !arguments[1][isTraitSymbol]) {
             return overloads.test.apply(this, arguments);
         } else if (arguments.length >= 2 && typeof arguments[0] !== "string" && typeof arguments[0] !== "function") {
@@ -416,7 +416,7 @@ function makeTestFunction(testFunc: () => Function, mark: null | string | symbol
             }
         },
         testDecorator(...traits: TestTrait[]): PropertyDecorator & MethodDecorator {
-            return function (target: Object, propertyKey: string | symbol, descriptor?: PropertyDescriptor): void {
+            return function(target: Object, propertyKey: string | symbol, descriptor?: PropertyDescriptor): void {
                 target[propertyKey][testNameSymbol] = propertyKey ? propertyKey.toString() : "";
                 target[propertyKey][traitsSymbol] = traits;
                 if (mark) {
@@ -425,7 +425,7 @@ function makeTestFunction(testFunc: () => Function, mark: null | string | symbol
             };
         },
         testDecoratorNamed(name: string, ...traits: TestTrait[]): PropertyDecorator & MethodDecorator {
-            return function (target: Object, propertyKey: string | symbol, descriptor?: PropertyDescriptor): void {
+            return function(target: Object, propertyKey: string | symbol, descriptor?: PropertyDescriptor): void {
                 target[propertyKey][testNameSymbol] = name;
                 target[propertyKey][traitsSymbol] = traits;
                 if (mark) {
@@ -454,7 +454,7 @@ export function trait<T extends SuiteTrait | TestTrait>(arg: T): T {
  * @param time The time in miliseconds.
  */
 export function slow(time: number): PropertyDecorator & ClassDecorator & SuiteTrait & TestTrait {
-    return trait(function () {
+    return trait(function() {
         if (arguments.length === 1) {
             const target = arguments[0];
             target[slowSymbol] = time;
@@ -487,7 +487,7 @@ export function slow(time: number): PropertyDecorator & ClassDecorator & SuiteTr
  * @param time The time in miliseconds.
  */
 export function timeout(time: number): MethodDecorator & PropertyDecorator & ClassDecorator & SuiteTrait & TestTrait {
-    return trait(function () {
+    return trait(function() {
         if (arguments.length === 1) {
             const target = arguments[0];
             target[timeoutSymbol] = time;
@@ -520,7 +520,7 @@ export function timeout(time: number): MethodDecorator & PropertyDecorator & Cla
  * @param count The number of retries to attempt when running the test.
  */
 export function retries(count: number): MethodDecorator & PropertyDecorator & ClassDecorator & SuiteTrait & TestTrait {
-    return trait(function () {
+    return trait(function() {
         if (arguments.length === 1) {
             const target = arguments[0];
             target[retriesSymbol] = count;
@@ -548,13 +548,13 @@ export function retries(count: number): MethodDecorator & PropertyDecorator & Cl
     });
 }
 
-export const skipOnError: SuiteTrait = trait(function (ctx, ctor) {
-    ctx.beforeEach(function () {
+export const skipOnError: SuiteTrait = trait(function(ctx, ctor) {
+    ctx.beforeEach(function() {
         if (ctor.__skip_all) {
             this.skip();
         }
     });
-    ctx.afterEach(function () {
+    ctx.afterEach(function() {
         if (this.currentTest.state === "failed") {
             ctor.__skip_all = true;
         }
@@ -614,7 +614,7 @@ export function context(target: Object, propertyKey: string | symbol): void {
 function tsdd(suite) {
     const suites = [suite];
 
-    suite.on("pre-require", function (context, file, mocha) {
+    suite.on("pre-require", function(context, file, mocha) {
         const common = Common(suites, context, mocha);
 
         context.before = common.before;
@@ -624,28 +624,28 @@ function tsdd(suite) {
         context.run = mocha.options.delay && common.runWithSuite(suite);
 
         // Copy of bdd
-        context.describe = context.context = function (title, fn) {
+        context.describe = context.context = function(title, fn) {
             return common.suite.create({
                 title,
                 file,
                 fn,
             });
         };
-        context.xdescribe = context.xcontext = context.describe.skip = function (title, fn) {
+        context.xdescribe = context.xcontext = context.describe.skip = function(title, fn) {
             return common.suite.skip({
                 title,
                 file,
                 fn,
             });
         };
-        context.describe.only = function (title, fn) {
+        context.describe.only = function(title, fn) {
             return common.suite.only({
                 title,
                 file,
                 fn,
             });
         };
-        context.it = context.specify = function (title, fn) {
+        context.it = context.specify = function(title, fn) {
             const suite = suites[0];
             if (suite.isPending()) {
                 fn = null;
@@ -655,13 +655,13 @@ function tsdd(suite) {
             suite.addTest(test);
             return test;
         };
-        context.it.only = function (title, fn) {
+        context.it.only = function(title, fn) {
             return common.test.only(mocha, context.it(title, fn));
         };
-        context.xit = context.xspecify = context.it.skip = function (title) {
+        context.xit = context.xspecify = context.it.skip = function(title) {
             context.it(title);
         };
-        context.it.retries = function (n) {
+        context.it.retries = function(n) {
             context.retries(n);
         };
 

--- a/index.ts
+++ b/index.ts
@@ -63,10 +63,10 @@ interface SuiteProto {
 export type SuiteTrait = (this: Mocha.ISuiteCallbackContext, ctx: Mocha.ISuiteCallbackContext, ctor: SuiteCtor) => void;
 export type TestTrait = (this: Mocha.ITestCallbackContext, ctx: Mocha.ITestCallbackContext, instance: SuiteProto, method: Function) => void;
 
-const noname = (cb: Function, innerFunction?: Function): () => any => {
+const noname = (cb: ((context, done?) => any), innerFunction?: Function): () => any => {
     if (innerFunction && cb) {
-        let wrapperResult: any = function() {
-            return cb.apply(this, arguments);
+        let wrapperResult: any = function(context) {
+            cb.apply(this, arguments);
         };
         if (cb.length === 2) {
             // we need to handle the done callback explicitly in the definition for mocha to respect it correctly

--- a/package.json
+++ b/package.json
@@ -28,21 +28,20 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@types/mocha": "^5.2.0",
-    "chalk": "^1.1.3",
-    "cross-spawn": "^5.1.0",
-    "yargs": "^6.5.0"
+    "chalk": "^2.4.1",
+    "cross-spawn": "^6.0.5",
+    "yargs": "^11.0.0"
   },
   "devDependencies": {
-    "@types/chai": "^3.4.35",
-    "@types/node": "^7.0.60",
-    "assert": "^1.3.0",
-    "better-assert": "^1.0.2",
-    "chai": "^3.5.0",
+    "@types/chai": "^4.1.3",
+    "@types/node": "^10.1.4",
+    "@types/cross-spawn": "^6.0.0",
+    "chai": "^4.1.2",
     "mocha": "^5.2.0",
-    "rimraf": "^2.6.1",
-    "source-map-support": "^0.4.15",
+    "rimraf": "^2.6.2",
+    "source-map-support": "^0.5.6",
     "tslint": "^5.10.0",
-    "typescript": "^2.4.1"
+    "typescript": "^2.9.1"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
When using Karma test runner, the test runner toStrings() method implementations for rendering the html output.

Currently using karma runner you would get this when inspecting the method:
![image](https://user-images.githubusercontent.com/9914123/40564186-9723610a-601c-11e8-99a4-0f88035ef736.png)


## The fix:
This change corrects the karma html viewer to show the correct test method implementation:
![image](https://user-images.githubusercontent.com/9914123/40564111-4eaac08a-601c-11e8-9cab-6bc1bb2a4db7.png)
